### PR TITLE
Add Docker support and fix .env.example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+LICENSE
+README.md

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-# discord auth token
 DISCORD_TOKEN=
+INFINITETRAIN_PATH=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:latest
+
+RUN apt-get update -y
+RUN apt-get install -y python3 python3-pip build-essential ffmpeg
+
+COPY . /app
+WORKDIR /app
+RUN pip3 install -r requirements.txt
+
+ENTRYPOINT ["python3"]
+CMD ["./src/__main__.py"]

--- a/README.md
+++ b/README.md
@@ -5,11 +5,38 @@ Uses [infinitetrain](https://github.com/aixxe/infinitetrain)
 
 ## Requirements
 
-- Built infinitetrain added to path
+- Built infinitetrain added to INFINITETRAIN_PATH environment variable
 - FFmpeg
 - Python 3.10+
+- Docker (optional)
 
-## Installation
+Songs are not included in this repository due to copyright reasons.
+
+## How to Run
+
+### With the Docker CLI
+
+Recommends using external .env file with Docker due to security reasons.
+
+```
+# Pull from docker hub
+$> docker pull misonoyuni/infinitetrain:latest
+
+# Prepare built infinitetrain and songs data in ./data directory, and Setting.env file in root directory
+
+# Settings.env
+DISCORD_TOKEN=INSERT YOUR TOKEN HERE
+INFINITETRAIN_PATH=/app/data/
+
+# Run
+$> docker run --name infinitetrain      \
+              --volume ./data:/app/data \
+              --env-file ./Settings.env \
+              --detach                  \
+              misonoyuni/infinite-train 
+```
+ 
+### Without the Docker CLI
 
 - Clone this repo
 - Create a new venv and run `pip install -r requirements.txt`


### PR DESCRIPTION
- Add Docker support, currently live on ``misonoyuni/infinitetrain``
- Fix .env.example file, INFINITETRAIN_TOKEN should have been there
- Update README.md to reflect changes described above